### PR TITLE
Inject the api key on datasource creation

### DIFF
--- a/pkg/plugin/queries.go
+++ b/pkg/plugin/queries.go
@@ -20,7 +20,7 @@ const (
 )
 
 // QueryMonitorErrors queries `/monitor-telemetry`
-func QueryMonitorErrors(ctx context.Context, query backend.DataQuery, client internal.ClientWithResponsesInterface, apiKey string) (backend.DataResponse, error) {
+func QueryMonitorErrors(ctx context.Context, query backend.DataQuery, client internal.ClientWithResponsesInterface) (backend.DataResponse, error) {
 	from, to := query.TimeRange.From.Format(time.RFC3339), query.TimeRange.To.Format(time.RFC3339)
 	var monitorTelemetryQuery monitorTelemetryQuery
 	if err := json.Unmarshal(query.JSON, &monitorTelemetryQuery); err != nil {
@@ -33,8 +33,7 @@ func QueryMonitorErrors(ctx context.Context, query backend.DataQuery, client int
 			To:            &to,
 			M:             &monitorTelemetryQuery.Monitors,
 			IncludeShared: &monitorTelemetryQuery.IncludeShared,
-		},
-		withAPIKey(apiKey))
+		})
 
 	if err != nil {
 		return backend.DataResponse{}, err
@@ -75,7 +74,7 @@ func QueryMonitorErrors(ctx context.Context, query backend.DataQuery, client int
 }
 
 // QueryMonitorTelemetry queries `/monitor-telemetry`
-func QueryMonitorTelemetry(ctx context.Context, query backend.DataQuery, client internal.ClientWithResponsesInterface, apiKey string) (backend.DataResponse, error) {
+func QueryMonitorTelemetry(ctx context.Context, query backend.DataQuery, client internal.ClientWithResponsesInterface) (backend.DataResponse, error) {
 	from, to := query.TimeRange.From.Format(time.RFC3339), query.TimeRange.To.Format(time.RFC3339)
 	var monitorTelemetryQuery monitorTelemetryQuery
 
@@ -89,8 +88,7 @@ func QueryMonitorTelemetry(ctx context.Context, query backend.DataQuery, client 
 			To:            &to,
 			M:             &monitorTelemetryQuery.Monitors,
 			IncludeShared: &monitorTelemetryQuery.IncludeShared,
-		},
-		withAPIKey(apiKey))
+		})
 
 	if err != nil {
 		return backend.DataResponse{}, err
@@ -130,7 +128,7 @@ func QueryMonitorTelemetry(ctx context.Context, query backend.DataQuery, client 
 }
 
 // QueryMonitorStatusPageChanges queries `/status-page-changes`
-func QueryMonitorStatusPageChanges(ctx context.Context, query backend.DataQuery, client internal.ClientWithResponsesInterface, apiKey string) (backend.DataResponse, error) {
+func QueryMonitorStatusPageChanges(ctx context.Context, query backend.DataQuery, client internal.ClientWithResponsesInterface) (backend.DataResponse, error) {
 	from, to := query.TimeRange.From.Format(time.RFC3339), query.TimeRange.To.Format(time.RFC3339)
 	var monitorTelemetryQuery monitorTelemetryQuery
 
@@ -143,7 +141,7 @@ func QueryMonitorStatusPageChanges(ctx context.Context, query backend.DataQuery,
 			From: from,
 			To:   &to,
 			M:    &monitorTelemetryQuery.Monitors,
-		}, withAPIKey(apiKey))
+		})
 
 	if err != nil {
 		return backend.DataResponse{}, err

--- a/pkg/plugin/resources.go
+++ b/pkg/plugin/resources.go
@@ -10,8 +10,8 @@ import (
 )
 
 // ResourceMonitorList returns a list of monitors which is can be used by a select box
-func ResourceMonitorList(ctx context.Context, client internal.ClientWithResponsesInterface, apiKey string) (backend.CallResourceResponse, error) {
-	resp, err := client.BackendWebMonitorListControllerGetWithResponse(ctx, withAPIKey(apiKey))
+func ResourceMonitorList(ctx context.Context, client internal.ClientWithResponsesInterface) (backend.CallResourceResponse, error) {
+	resp, err := client.BackendWebMonitorListControllerGetWithResponse(ctx)
 	if err != nil {
 		return backend.CallResourceResponse{}, err
 	}

--- a/pkg/plugin/resources_test.go
+++ b/pkg/plugin/resources_test.go
@@ -13,7 +13,6 @@ import (
 func TestResourceMonitorList(t *testing.T) {
 	type args struct {
 		client internal.ClientWithResponsesInterface
-		apiKey string
 	}
 	tests := []struct {
 		name    string
@@ -24,7 +23,6 @@ func TestResourceMonitorList(t *testing.T) {
 		{
 			name: "serializes list of monitors properly properly",
 			args: args{
-				apiKey: "OK",
 				client: &stubClient{monitorListResponse: internal.BackendWebMonitorListControllerGetResponse{
 					JSON200: &internal.MonitorList{{LogicalName: ptr("AWS Lambda"), Name: ptr("awslambda")}},
 				}},
@@ -38,7 +36,6 @@ func TestResourceMonitorList(t *testing.T) {
 		{
 			name: "handles empty monitor list",
 			args: args{
-				apiKey: "OK",
 				client: &stubClient{monitorListResponse: internal.BackendWebMonitorListControllerGetResponse{
 					JSON200: &internal.MonitorList{},
 				}},
@@ -52,7 +49,7 @@ func TestResourceMonitorList(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := ResourceMonitorList(context.Background(), tt.args.client, tt.args.apiKey)
+			got, err := ResourceMonitorList(context.Background(), tt.args.client)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("ResourceMonitorList() error = %v, wantErr %v", err, tt.wantErr)
 				return


### PR DESCRIPTION
Instead of passing the api key everywhere, we can inject it on datasource creation instead