### PR TITLE
Fix console js bug in new versions of grafana causing graphs to not refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,9 @@ Initial dev build
 ## 0.0.2 (Unreleased)
 
 Update release zip name to always be metrist-datasource.zip
+
+## 0.0.3 (Unreleased)
+
+- Fixed error caused by invalid data frames that would sometimes cause the graphs not to refresh and would emit js console errors
+- Added Wide frames for table layout in Explore mode
+

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,7 +6,7 @@ services:
     build:
       context: ./.config
       args:
-        grafana_version: ${GRAFANA_VERSION:-9.2.5}
+        grafana_version: ${GRAFANA_VERSION:-9.3.6}
     ports:
       - 3000:3000/tcp
     volumes:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metrist-datasource",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",

--- a/pkg/internal/api_helpers.go
+++ b/pkg/internal/api_helpers.go
@@ -1,0 +1,177 @@
+// Some helpers around the auto generated openapi.go structs for easy grafana data.Frame creation across auto created types
+package internal
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/data"
+)
+
+type FrameData interface {
+	GetTimestamp() (time.Time, error)
+	GetGraphVals(timestamp time.Time) []any
+	GetTableVals(timestamp time.Time) []any
+	GetKey() string
+	GetGraphFrameDefinition() data.Frame
+	GetTableFrameDefinition() data.Frame
+
+	getLabels() map[string]string
+}
+
+// Monitor Errors
+func (errorCount *MonitorErrorCount) GetTimestamp() (time.Time, error) {
+	return time.Parse(time.RFC3339, *errorCount.Timestamp)
+}
+
+func (errorCount *MonitorErrorCount) GetGraphVals(timestamp time.Time) []any {
+	return []any{timestamp, int64(*errorCount.Count)}
+}
+
+func (errorCount *MonitorErrorCount) GetTableVals(timestamp time.Time) []any {
+	return []any{timestamp, int64(*errorCount.Count), *errorCount.Instance, *errorCount.Check, *errorCount.MonitorLogicalName}
+}
+
+func (errorCount *MonitorErrorCount) GetKey() string {
+	return fmt.Sprintf("%s-%s-%s", *errorCount.Instance, *errorCount.Check, *errorCount.MonitorLogicalName)
+}
+
+func (errorCount *MonitorErrorCount) GetGraphFrameDefinition() data.Frame {
+	return data.Frame{
+		Fields: []*data.Field{
+			data.NewField("time", nil, make([]time.Time, 0)),
+			data.NewField("count", errorCount.getLabels(), make([]int64, 0)),
+		},
+		Meta: &data.FrameMeta{
+			Type: data.FrameTypeTimeSeriesMulti,
+		},
+	}
+}
+
+func (errorCount *MonitorErrorCount) GetTableFrameDefinition() data.Frame {
+	return data.Frame{
+		Fields: []*data.Field{
+			data.NewField("time", nil, []time.Time{}),
+			data.NewField("count", nil, []int64{}),
+			data.NewField("instance", nil, []string{}),
+			data.NewField("check", nil, []string{}),
+			data.NewField("monitor", nil, []string{}),
+		},
+		Meta: &data.FrameMeta{
+			Type:                   data.FrameTypeTimeSeriesWide,
+			PreferredVisualization: data.VisTypeTable,
+		},
+	}
+}
+
+func (errorCount *MonitorErrorCount) getLabels() map[string]string {
+	return map[string]string{"instance": *errorCount.Instance, "check": *errorCount.Check, "monitor": *errorCount.MonitorLogicalName}
+}
+
+// Monitor Telemetry
+func (te *MonitorTelemetry) GetTimestamp() (time.Time, error) {
+	return time.Parse(time.RFC3339, *te.Timestamp)
+}
+
+func (te *MonitorTelemetry) GetGraphVals(timestamp time.Time) []any {
+	return []any{timestamp, *te.Value}
+}
+
+func (te *MonitorTelemetry) GetTableVals(timestamp time.Time) []any {
+	return []any{timestamp, *te.Value, *te.Instance, *te.Check, *te.MonitorLogicalName}
+}
+
+func (te *MonitorTelemetry) GetKey() string {
+	return fmt.Sprintf("%s-%s-%s", *te.Instance, *te.Check, *te.MonitorLogicalName)
+}
+
+func (te *MonitorTelemetry) GetGraphFrameDefinition() data.Frame {
+	return data.Frame{
+		Fields: []*data.Field{
+			data.NewField("time", nil, make([]time.Time, 0)),
+			data.NewField("response time (ms)", te.getLabels(), make([]float32, 0)),
+		},
+		Meta: &data.FrameMeta{
+			Type: data.FrameTypeTimeSeriesMulti,
+		},
+	}
+}
+
+func (te *MonitorTelemetry) GetTableFrameDefinition() data.Frame {
+	return data.Frame{
+		Fields: []*data.Field{
+			data.NewField("time", nil, []time.Time{}),
+			data.NewField("response time (ms)", nil, []float32{}),
+			data.NewField("instance", nil, []string{}),
+			data.NewField("check", nil, []string{}),
+			data.NewField("monitor", nil, []string{}),
+		},
+		Meta: &data.FrameMeta{
+			Type:                   data.FrameTypeTimeSeriesWide,
+			PreferredVisualization: data.VisTypeTable,
+		},
+	}
+}
+
+func (te *MonitorTelemetry) getLabels() map[string]string {
+	return map[string]string{"instance": *te.Instance, "check": *te.Check, "monitor": *te.MonitorLogicalName}
+}
+
+// Status Page Changes
+func (spc *StatusPageComponentChange) GetTimestamp() (time.Time, error) {
+	return time.Parse(time.RFC3339, *spc.Timestamp)
+}
+
+func (spc *StatusPageComponentChange) GetGraphVals(timestamp time.Time) []any {
+	return []any{timestamp, spcStatusToInt(*spc.Status)}
+}
+
+func (spc *StatusPageComponentChange) GetTableVals(timestamp time.Time) []any {
+	return []any{timestamp, spcStatusToInt(*spc.Status), *spc.Component, *spc.MonitorLogicalName}
+}
+
+func (spc *StatusPageComponentChange) GetKey() string {
+	return fmt.Sprintf("%s-%s", *spc.Component, *spc.MonitorLogicalName)
+}
+
+func (spc *StatusPageComponentChange) GetGraphFrameDefinition() data.Frame {
+	return data.Frame{
+		Fields: []*data.Field{
+			data.NewField("time", nil, make([]time.Time, 0)),
+			data.NewField("status", spc.getLabels(), make([]int8, 0)),
+		},
+		Meta: &data.FrameMeta{
+			Type: data.FrameTypeTimeSeriesMulti,
+		},
+	}
+}
+
+func (spc *StatusPageComponentChange) GetTableFrameDefinition() data.Frame {
+	return data.Frame{
+		Fields: []*data.Field{
+			data.NewField("time", nil, []time.Time{}),
+			data.NewField("status", nil, []int8{}),
+			data.NewField("component", nil, []string{}),
+			data.NewField("monitor", nil, []string{}),
+		},
+		Meta: &data.FrameMeta{
+			Type:                   data.FrameTypeTimeSeriesWide,
+			PreferredVisualization: data.VisTypeTable,
+		},
+	}
+}
+
+func (spc *StatusPageComponentChange) getLabels() map[string]string {
+	return map[string]string{"component": *spc.Component, "monitor": *spc.MonitorLogicalName}
+}
+
+func spcStatusToInt(status string) int8 {
+	statuses := map[string]int8{
+		"up":          0,
+		"operational": 0,
+		"degraded":    1,
+		"down":        2,
+	}
+	result := statuses[status]
+	return result
+}

--- a/pkg/internal/openapi.go
+++ b/pkg/internal/openapi.go
@@ -27,13 +27,13 @@ const (
 	Exe MonitorConfigRunSpecRunType = "exe"
 )
 
-// Defines values for MonitorStatusesState.
+// Defines values for MonitorStatusesResponseState.
 const (
-	Degraded    MonitorStatusesState = "degraded"
-	Down        MonitorStatusesState = "down"
-	Issues      MonitorStatusesState = "issues"
-	Maintenance MonitorStatusesState = "maintenance"
-	Up          MonitorStatusesState = "up"
+	Degraded    MonitorStatusesResponseState = "degraded"
+	Down        MonitorStatusesResponseState = "down"
+	Issues      MonitorStatusesResponseState = "issues"
+	Maintenance MonitorStatusesResponseState = "maintenance"
+	Up          MonitorStatusesResponseState = "up"
 )
 
 // MonitorCheck A single monitor check
@@ -45,8 +45,8 @@ type MonitorCheck struct {
 	Name *string `json:"name,omitempty"`
 }
 
-// MonitorChecks A list of monitors + their checks
-type MonitorChecks = []struct {
+// MonitorChecksResponse A list of monitors + their checks
+type MonitorChecksResponse = []struct {
 	// Checks The unique checks for that monitor
 	Checks *[]MonitorCheck `json:"checks,omitempty"`
 
@@ -112,8 +112,8 @@ type MonitorErrorResponse struct {
 	Metadata *PagingMetadata `json:"metadata,omitempty"`
 }
 
-// MonitorInstances A list of monitors + their instances
-type MonitorInstances = []struct {
+// MonitorInstancesResponse A list of monitors + their instances
+type MonitorInstancesResponse = []struct {
 	// Instances The unique instances for that monitor
 	Instances *[]string `json:"instances,omitempty"`
 
@@ -121,8 +121,8 @@ type MonitorInstances = []struct {
 	MonitorLogicalName *string `json:"monitor_logical_name,omitempty"`
 }
 
-// MonitorList A list of monitors
-type MonitorList = []struct {
+// MonitorListResponse A list of monitors
+type MonitorListResponse = []struct {
 	// LogicalName The logical name of the monitor
 	LogicalName *string `json:"logical_name,omitempty"`
 
@@ -130,8 +130,8 @@ type MonitorList = []struct {
 	Name *string `json:"name,omitempty"`
 }
 
-// MonitorStatuses A collection of monitor statuses
-type MonitorStatuses = []struct {
+// MonitorStatusesResponse A collection of monitor statuses
+type MonitorStatusesResponse = []struct {
 	// LastChecked The last time this monitor was checked by Metrist
 	LastChecked *string `json:"last_checked,omitempty"`
 
@@ -139,14 +139,14 @@ type MonitorStatuses = []struct {
 	MonitorLogicalName *string `json:"monitor_logical_name,omitempty"`
 
 	// State The state of the monitor up, degraded, issues, down, maintenance
-	State *MonitorStatusesState `json:"state,omitempty"`
+	State *MonitorStatusesResponseState `json:"state,omitempty"`
 }
 
-// MonitorStatusesState The state of the monitor up, degraded, issues, down, maintenance
-type MonitorStatusesState string
+// MonitorStatusesResponseState The state of the monitor up, degraded, issues, down, maintenance
+type MonitorStatusesResponseState string
 
 // MonitorTelemetry A collection of Telemetry Entries
-type MonitorTelemetry = []struct {
+type MonitorTelemetry struct {
 	// Check Check that generated the telemetry
 	Check *string `json:"check,omitempty"`
 
@@ -163,6 +163,9 @@ type MonitorTelemetry = []struct {
 	Value *float32 `json:"value,omitempty"`
 }
 
+// MonitorTelemetryResponse An array of MonitorTelemetry
+type MonitorTelemetryResponse = []MonitorTelemetry
+
 // PagingMetadata Provides cursor data for an API request
 type PagingMetadata struct {
 	// CursorAfter an opaque cursor representing the last row of the current page
@@ -170,6 +173,15 @@ type PagingMetadata struct {
 
 	// CursorBefore an opaque cursor representing the first row of the current page
 	CursorBefore *string `json:"cursor_before,omitempty"`
+}
+
+// StatusPageChangesResponse A collection of Status Page Component Changes
+type StatusPageChangesResponse struct {
+	// Entries Returned values
+	Entries *[]StatusPageComponentChange `json:"entries,omitempty"`
+
+	// Metadata Provides cursor data for an API request
+	Metadata *PagingMetadata `json:"metadata,omitempty"`
 }
 
 // StatusPageComponentChange A single change for a single status page component
@@ -188,15 +200,6 @@ type StatusPageComponentChange struct {
 
 	// Timestamp Time when the change occurred
 	Timestamp *string `json:"timestamp,omitempty"`
-}
-
-// StatusPageComponentChanges A collection of Status Page Component Changes
-type StatusPageComponentChanges struct {
-	// Entries Returned values
-	Entries *[]StatusPageComponentChange `json:"entries,omitempty"`
-
-	// Metadata Provides cursor data for an API request
-	Metadata *PagingMetadata `json:"metadata,omitempty"`
 }
 
 // BackendWebMonitorCheckControllerGetParams defines parameters for BackendWebMonitorCheckControllerGet.
@@ -1311,7 +1314,7 @@ type ClientWithResponsesInterface interface {
 type BackendWebMonitorCheckControllerGetResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *MonitorChecks
+	JSON200      *MonitorChecksResponse
 }
 
 // Status returns HTTPResponse.Status
@@ -1397,7 +1400,7 @@ func (r BackendWebMonitorErrorControllerGetResponse) StatusCode() int {
 type BackendWebMonitorInstanceControllerGetResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *MonitorInstances
+	JSON200      *MonitorInstancesResponse
 }
 
 // Status returns HTTPResponse.Status
@@ -1419,7 +1422,7 @@ func (r BackendWebMonitorInstanceControllerGetResponse) StatusCode() int {
 type BackendWebMonitorListControllerGetResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *MonitorList
+	JSON200      *MonitorListResponse
 }
 
 // Status returns HTTPResponse.Status
@@ -1441,7 +1444,7 @@ func (r BackendWebMonitorListControllerGetResponse) StatusCode() int {
 type BackendWebMonitorStatusControllerGetResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *MonitorStatuses
+	JSON200      *MonitorStatusesResponse
 }
 
 // Status returns HTTPResponse.Status
@@ -1463,7 +1466,7 @@ func (r BackendWebMonitorStatusControllerGetResponse) StatusCode() int {
 type BackendWebStatusPageChangeControllerGetResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *StatusPageComponentChanges
+	JSON200      *StatusPageChangesResponse
 }
 
 // Status returns HTTPResponse.Status
@@ -1485,7 +1488,7 @@ func (r BackendWebStatusPageChangeControllerGetResponse) StatusCode() int {
 type BackendWebMonitorTelemetryControllerGetResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *MonitorTelemetry
+	JSON200      *MonitorTelemetryResponse
 }
 
 // Status returns HTTPResponse.Status
@@ -1638,7 +1641,7 @@ func ParseBackendWebMonitorCheckControllerGetResponse(rsp *http.Response) (*Back
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest MonitorChecks
+		var dest MonitorChecksResponse
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -1722,7 +1725,7 @@ func ParseBackendWebMonitorInstanceControllerGetResponse(rsp *http.Response) (*B
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest MonitorInstances
+		var dest MonitorInstancesResponse
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -1748,7 +1751,7 @@ func ParseBackendWebMonitorListControllerGetResponse(rsp *http.Response) (*Backe
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest MonitorList
+		var dest MonitorListResponse
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -1774,7 +1777,7 @@ func ParseBackendWebMonitorStatusControllerGetResponse(rsp *http.Response) (*Bac
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest MonitorStatuses
+		var dest MonitorStatusesResponse
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -1800,7 +1803,7 @@ func ParseBackendWebStatusPageChangeControllerGetResponse(rsp *http.Response) (*
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest StatusPageComponentChanges
+		var dest StatusPageChangesResponse
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -1826,7 +1829,7 @@ func ParseBackendWebMonitorTelemetryControllerGetResponse(rsp *http.Response) (*
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest MonitorTelemetry
+		var dest MonitorTelemetryResponse
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}

--- a/pkg/plugin/datasource_test.go
+++ b/pkg/plugin/datasource_test.go
@@ -27,7 +27,7 @@ func TestQueryMonitorTelemetry(t *testing.T) {
 			name: "Returns a dataframe if client returns telemetry",
 			client: stubClient{
 				telemetryResponse: internal.BackendWebMonitorTelemetryControllerGetResponse{
-					JSON200: &internal.MonitorTelemetry{{
+					JSON200: &internal.MonitorTelemetryResponse{internal.MonitorTelemetry{
 						Check:              ptr("Check"),
 						Instance:           ptr("us-east-1"),
 						MonitorLogicalName: ptr("awslambda"),
@@ -59,7 +59,7 @@ func TestQueryMonitorTelemetry(t *testing.T) {
 			name: "Returns an empty frame if no response",
 			client: stubClient{
 				telemetryResponse: internal.BackendWebMonitorTelemetryControllerGetResponse{
-					JSON200: &internal.MonitorTelemetry{},
+					JSON200: &internal.MonitorTelemetryResponse{},
 				},
 			},
 			want: data.Frames{},
@@ -97,13 +97,13 @@ func TestQueryMonitorStatusPageChanges(t *testing.T) {
 	}
 	query := []byte(`{"monitors": ["awslambda"], "includeShared": true, "queryType": "GetMonitorStatusPageChanges"}`)
 	tests := []struct {
-		page *internal.StatusPageComponentChanges
+		page *internal.StatusPageChangesResponse
 		name string
 		want data.Frames
 	}{
 		{
 			name: "Returns a dataframe if client returns telemetry",
-			page: &internal.StatusPageComponentChanges{
+			page: &internal.StatusPageChangesResponse{
 				Metadata: &internal.PagingMetadata{},
 				Entries: &[]internal.StatusPageComponentChange{{
 					Component:          ptr("component1"),
@@ -132,7 +132,7 @@ func TestQueryMonitorStatusPageChanges(t *testing.T) {
 		},
 		{
 			name: "Returns an empty frame if no response",
-			page: &internal.StatusPageComponentChanges{
+			page: &internal.StatusPageChangesResponse{
 				Metadata: &internal.PagingMetadata{},
 				Entries:  &[]internal.StatusPageComponentChange{},
 			},

--- a/pkg/plugin/datasource_test.go
+++ b/pkg/plugin/datasource_test.go
@@ -37,13 +37,23 @@ func TestQueryMonitorTelemetry(t *testing.T) {
 				},
 			},
 			want: data.Frames{{
-				Name: DataFrameMonitorTelemetry,
 				Fields: []*data.Field{
 					data.NewField("time", nil, []time.Time{strToTime("2022-12-07T18:28:06.485416Z")}),
-					data.NewField("", data.Labels{"instance": "us-east-1", "check": "Check", "monitor": "awslambda"}, []float32{value}),
+					data.NewField("response time (ms)", data.Labels{"instance": "us-east-1", "check": "Check", "monitor": "awslambda"}, []float32{value}),
 				},
-				Meta: &data.FrameMeta{Type: data.FrameTypeTimeSeriesWide},
-			}},
+				Meta: &data.FrameMeta{Type: data.FrameTypeTimeSeriesMulti},
+			},
+				{
+					Fields: []*data.Field{
+						data.NewField("time", nil, []time.Time{strToTime("2022-12-07T18:28:06.485416Z")}),
+						data.NewField("response time (ms)", nil, []float32{100}),
+						data.NewField("instance", nil, []string{"us-east-1"}),
+						data.NewField("check", nil, []string{"Check"}),
+						data.NewField("monitor", nil, []string{"awslambda"}),
+					},
+					Meta: &data.FrameMeta{Type: data.FrameTypeTimeSeriesWide, PreferredVisualization: data.VisTypeTable},
+				},
+			},
 		},
 		{
 			name: "Returns an empty frame if no response",
@@ -103,13 +113,22 @@ func TestQueryMonitorStatusPageChanges(t *testing.T) {
 				}},
 			},
 			want: data.Frames{{
-				Name: DataFrameMonitorStatusPageChanges,
 				Fields: []*data.Field{
 					data.NewField("time", nil, []time.Time{strToTime("2022-12-07T18:28:06.485416Z")}),
-					data.NewField("", data.Labels{"component": "component1", "monitor": "monitor"}, []int8{0}),
+					data.NewField("status", data.Labels{"component": "component1", "monitor": "monitor"}, []int8{0}),
 				},
-				Meta: &data.FrameMeta{Type: data.FrameTypeTimeSeriesWide},
-			}},
+				Meta: &data.FrameMeta{Type: data.FrameTypeTimeSeriesMulti},
+			},
+				{
+					Fields: []*data.Field{
+						data.NewField("time", nil, []time.Time{strToTime("2022-12-07T18:28:06.485416Z")}),
+						data.NewField("status", nil, []int8{0}),
+						data.NewField("component", nil, []string{"component1"}),
+						data.NewField("monitor", nil, []string{"monitor"}),
+					},
+					Meta: &data.FrameMeta{Type: data.FrameTypeTimeSeriesWide, PreferredVisualization: data.VisTypeTable},
+				},
+			},
 		},
 		{
 			name: "Returns an empty frame if no response",
@@ -160,7 +179,7 @@ func TestQueryMonitorErrors(t *testing.T) {
 		To:   time.Now(),
 		From: time.Now().Add(time.Hour * time.Duration(-100)),
 	}
-	query := []byte(`{"monitors": ["awslambda"], "includeShared": true, "queryType": "GetMonitorErrors"}`)
+	query := []byte(`{"monitors": ["awslambda"], "includeShared": false, "queryType": "GetMonitorErrors"}`)
 	tests := []struct {
 		page *internal.MonitorErrorResponse
 		name string
@@ -179,13 +198,23 @@ func TestQueryMonitorErrors(t *testing.T) {
 				Metadata: &internal.PagingMetadata{},
 			},
 			want: data.Frames{{
-				Name: DataFrameMonitorErrors,
 				Fields: []*data.Field{
 					data.NewField("time", nil, []time.Time{strToTime("2022-12-07T18:28:06.485416Z")}),
-					data.NewField("", data.Labels{"check": "check", "monitor": "monitor", "instance": "us-east-1"}, []int64{1}),
+					data.NewField("count", data.Labels{"check": "check", "monitor": "monitor", "instance": "us-east-1"}, []int64{1}),
 				},
-				Meta: &data.FrameMeta{Type: data.FrameTypeTimeSeriesWide},
-			}},
+				Meta: &data.FrameMeta{Type: data.FrameTypeTimeSeriesMulti},
+			},
+				{
+					Fields: []*data.Field{
+						data.NewField("time", nil, []time.Time{strToTime("2022-12-07T18:28:06.485416Z")}),
+						data.NewField("count", nil, []int64{1}),
+						data.NewField("instance", nil, []string{"us-east-1"}),
+						data.NewField("check", nil, []string{"check"}),
+						data.NewField("monitor", nil, []string{"monitor"}),
+					},
+					Meta: &data.FrameMeta{Type: data.FrameTypeTimeSeriesWide, PreferredVisualization: data.VisTypeTable},
+				},
+			},
 		},
 		{
 			name: "Returns an empty frame if no response",

--- a/pkg/plugin/queries.go
+++ b/pkg/plugin/queries.go
@@ -26,124 +26,7 @@ const (
 	maxPageCount = 20
 )
 
-type frameData interface {
-	getTimestamp() (time.Time, error)
-	getGraphVals(timestamp time.Time) []any
-	getTableVals(timestamp time.Time) []any
-	getKey() string
-	getLabels() map[string]string
-
-	getGraphFrameDefinition() data.Frame
-	getTableFrameDefinition() data.Frame
-}
-
-type monitorErrorCount internal.MonitorErrorCount
-
-type frameType int64
-
-const (
-	GraphFrameType frameType = 0
-	TableFrameType frameType = 1
-)
-
-func (errorCount *monitorErrorCount) getTimestamp() (time.Time, error) {
-	return time.Parse(time.RFC3339, *errorCount.Timestamp)
-}
-
-func (errorCount *monitorErrorCount) getGraphVals(timestamp time.Time) []any {
-	return []any{timestamp, int64(*errorCount.Count)}
-}
-
-func (errorCount *monitorErrorCount) getTableVals(timestamp time.Time) []any {
-	return []any{timestamp, int64(*errorCount.Count), *errorCount.Instance, *errorCount.Check, *errorCount.MonitorLogicalName}
-}
-
-func (errorCount *monitorErrorCount) getKey() string {
-	return fmt.Sprintf("%s-%s-%s", *errorCount.Instance, *errorCount.Check, *errorCount.MonitorLogicalName)
-}
-
-func (errorCount *monitorErrorCount) getLabels() map[string]string {
-	return map[string]string{"instance": *errorCount.Instance, "check": *errorCount.Check, "monitor": *errorCount.MonitorLogicalName}
-}
-
-func (errorCount *monitorErrorCount) getGraphFrameDefinition() data.Frame {
-	return data.Frame{
-		Fields: []*data.Field{
-			data.NewField("time", nil, make([]time.Time, 0)),
-			data.NewField("count", errorCount.getLabels(), make([]int64, 0)),
-		},
-		Meta: &data.FrameMeta{
-			Type: data.FrameTypeTimeSeriesMulti,
-		},
-	}
-}
-
-func (errorCount *monitorErrorCount) getTableFrameDefinition() data.Frame {
-	return data.Frame{
-		Fields: []*data.Field{
-			data.NewField("time", nil, []time.Time{}),
-			data.NewField("count", nil, []int64{}),
-			data.NewField("instance", nil, []string{}),
-			data.NewField("check", nil, []string{}),
-			data.NewField("monitor", nil, []string{}),
-		},
-		Meta: &data.FrameMeta{
-			Type:                   data.FrameTypeTimeSeriesWide,
-			PreferredVisualization: data.VisTypeTable,
-		},
-	}
-}
-
-func buildFrames(responses []frameData, frameType frameType, frames []*data.Frame) []*data.Frame {
-	frameMap := make(map[string]*data.Frame)
-
-	for _, frameDataItem := range responses {
-		timestamp, err := frameDataItem.getTimestamp()
-		if err != nil {
-			log.DefaultLogger.Error("error while parsing time %w", err)
-			continue
-		}
-		key := frameDataItem.getKey()
-		frameToAppendTo, ok := frameMap[key]
-		if !ok {
-			frameDefinition := getFrameDefinitionFunction(frameType, frameDataItem)()
-			frameToAppendTo = &frameDefinition
-			frameMap[key] = frameToAppendTo
-		}
-
-		vals := getValDefinitionFunction(frameType, frameDataItem)(timestamp)
-		frameToAppendTo.AppendRow(vals...)
-	}
-	for _, frame := range frameMap {
-		frames = append(frames, frame)
-	}
-
-	return frames
-}
-
-func getFrameDefinitionFunction(frameType frameType, frameData frameData) func() data.Frame {
-	switch frameType {
-	case GraphFrameType:
-		return frameData.getGraphFrameDefinition
-	case TableFrameType:
-		return frameData.getTableFrameDefinition
-	}
-
-	return nil
-}
-
-func getValDefinitionFunction(frameType frameType, frameData frameData) func(time.Time) []any {
-	switch frameType {
-	case GraphFrameType:
-		return frameData.getGraphVals
-	case TableFrameType:
-		return frameData.getTableVals
-	}
-
-	return nil
-}
-
-// QueryMonitorErrors queries `/monitor-errors`
+// QueryMonitorErrors queries `/monitor-telemetry`
 func QueryMonitorErrors(ctx context.Context, query backend.DataQuery, client internal.ClientWithResponsesInterface) (backend.DataResponse, error) {
 	var monitorTelemetryQuery monitorTelemetryQuery
 	if err := json.Unmarshal(query.JSON, &monitorTelemetryQuery); err != nil {
@@ -159,17 +42,73 @@ func QueryMonitorErrors(ctx context.Context, query backend.DataQuery, client int
 		return backend.DataResponse{}, nil
 	}
 
-	coerced_counts := make([]frameData, len(responses))
-	for i := range responses {
-		newVar := monitorErrorCount(responses[i])
-		coerced_counts[i] = &newVar
+	// We are going to generate 2 frame sets. one for graph display and one for table display
+	graphFrameMap := make(map[string]*data.Frame)
+	tableFrameMap := make(map[string]*data.Frame)
+	frames := make([]*data.Frame, 0)
+
+	for _, monitorError := range responses {
+		timestamp, err := time.Parse(time.RFC3339, *monitorError.Timestamp)
+		if err != nil {
+			log.DefaultLogger.Error("error while parsing monitor error time %w", err)
+			continue
+		}
+
+		key := fmt.Sprintf("%s-%s-%s", *monitorError.Instance, *monitorError.Check, *monitorError.MonitorLogicalName)
+
+		frameToAppendTo, ok := graphFrameMap[key]
+		if !ok {
+			labels := map[string]string{"instance": *monitorError.Instance, "check": *monitorError.Check, "monitor": *monitorError.MonitorLogicalName}
+
+			frameToAppendTo = &data.Frame{
+				Fields: []*data.Field{
+					data.NewField("time", nil, make([]time.Time, 0)),
+					data.NewField("count", labels, make([]int64, 0)),
+				},
+				Meta: &data.FrameMeta{
+					Type: data.FrameTypeTimeSeriesMulti,
+				},
+			}
+
+			graphFrameMap[key] = frameToAppendTo
+		}
+
+		frameToAppendTo.AppendRow(timestamp, int64(*monitorError.Count))
+
+		frameToAppendTo, ok = tableFrameMap[key]
+		if !ok {
+			frameToAppendTo = &data.Frame{
+				Fields: []*data.Field{
+					data.NewField("time", nil, []time.Time{}),
+					data.NewField("count", nil, []int64{}),
+					data.NewField("instance", nil, []string{}),
+					data.NewField("check", nil, []string{}),
+					data.NewField("monitor", nil, []string{}),
+				},
+				Meta: &data.FrameMeta{
+					Type:                   data.FrameTypeTimeSeriesWide,
+					PreferredVisualization: data.VisTypeTable,
+				},
+			}
+
+			tableFrameMap[key] = frameToAppendTo
+		}
+		frameToAppendTo.AppendRow(timestamp, int64(*monitorError.Count), *monitorError.Instance, *monitorError.Check, *monitorError.MonitorLogicalName)
 	}
 
-	frames := make([]*data.Frame, 0)
-	frames = buildFrames(coerced_counts, GraphFrameType, frames)
-	if !monitorTelemetryQuery.FromAlerting {
-		frames = buildFrames(coerced_counts, TableFrameType, frames)
+	for _, frame := range graphFrameMap {
+		frames = append(frames, frame)
 	}
+
+	// If this query is coming from CloudAlerting or Unified alerting do not include the table frames
+	// The table frames are not FrameTypeTimeSeriesWide format which alerting won't accept
+	// See https://github.com/grafana/grafana-plugin-sdk-go/blob/main/data/contract_docs/timeseries.md#time-series-multi-format-timeseriesmulti
+	if !monitorTelemetryQuery.FromAlerting {
+		for _, frame := range tableFrameMap {
+			frames = append(frames, frame)
+		}
+	}
+
 	return backend.DataResponse{Frames: frames}, nil
 }
 

--- a/pkg/plugin/queries.go
+++ b/pkg/plugin/queries.go
@@ -305,17 +305,6 @@ func fetchAllStatusPageMonitor(ctx context.Context, client internal.ClientWithRe
 	return monitorStatuses, nil
 }
 
-func spcStatusToInt(status string) int8 {
-	statuses := map[string]int8{
-		"up":          0,
-		"operational": 0,
-		"degraded":    1,
-		"down":        2,
-	}
-	result := statuses[status]
-	return result
-}
-
 func withAPIKey(apiKey string) internal.RequestEditorFn {
 	return func(ctx context.Context, req *http.Request) error {
 		req.Header.Add("Authorization", apiKey)

--- a/pkg/plugin/resources_test.go
+++ b/pkg/plugin/resources_test.go
@@ -27,7 +27,7 @@ func TestResourceMonitorList(t *testing.T) {
 			name: "serializes list of monitors properly properly",
 			args: testArgsWithClientWithResponse{
 				client: &stubClient{monitorListResponse: internal.BackendWebMonitorListControllerGetResponse{
-					JSON200: &internal.MonitorList{{LogicalName: ptr("AWS Lambda"), Name: ptr("awslambda")}},
+					JSON200: &internal.MonitorListResponse{{LogicalName: ptr("AWS Lambda"), Name: ptr("awslambda")}},
 				}},
 			},
 			want: backend.CallResourceResponse{
@@ -40,7 +40,7 @@ func TestResourceMonitorList(t *testing.T) {
 			name: "handles empty monitor list",
 			args: testArgsWithClientWithResponse{
 				client: &stubClient{monitorListResponse: internal.BackendWebMonitorListControllerGetResponse{
-					JSON200: &internal.MonitorList{},
+					JSON200: &internal.MonitorListResponse{},
 				}},
 			},
 			want: backend.CallResourceResponse{
@@ -70,7 +70,7 @@ func TestResourceChecksList(t *testing.T) {
 			name: "serializes list of checks properly properly with proper combining of monitor names",
 			args: testArgsWithClientWithResponse{
 				client: &stubClient{checksResponse: internal.BackendWebMonitorCheckControllerGetResponse{
-					JSON200: &internal.MonitorChecks{
+					JSON200: &internal.MonitorChecksResponse{
 						{
 							Checks: &[]internal.MonitorCheck{
 								{
@@ -102,7 +102,7 @@ func TestResourceChecksList(t *testing.T) {
 			name: "handles empty checks list",
 			args: testArgsWithClientWithResponse{
 				client: &stubClient{checksResponse: internal.BackendWebMonitorCheckControllerGetResponse{
-					JSON200: &internal.MonitorChecks{},
+					JSON200: &internal.MonitorChecksResponse{},
 				}},
 			},
 			want: backend.CallResourceResponse{
@@ -132,7 +132,7 @@ func TestInstancesList(t *testing.T) {
 			name: "serializes list of instances properly removing duplicates",
 			args: testArgsWithClientWithResponse{
 				client: &stubClient{instancesResponse: internal.BackendWebMonitorInstanceControllerGetResponse{
-					JSON200: &internal.MonitorInstances{
+					JSON200: &internal.MonitorInstancesResponse{
 						{
 							Instances: &[]string{
 								"instance1",
@@ -159,7 +159,7 @@ func TestInstancesList(t *testing.T) {
 			name: "handles empty instances list",
 			args: testArgsWithClientWithResponse{
 				client: &stubClient{instancesResponse: internal.BackendWebMonitorInstanceControllerGetResponse{
-					JSON200: &internal.MonitorInstances{},
+					JSON200: &internal.MonitorInstancesResponse{},
 				}},
 			},
 			want: backend.CallResourceResponse{

--- a/pkg/plugin/types.go
+++ b/pkg/plugin/types.go
@@ -12,7 +12,7 @@ type monitorTelemetryQuery struct {
 	Checks        *[]string `json:"checks"`
 	Instances     *[]string `json:"instances"`
 	IncludeShared bool      `json:"includeshared"`
-	FromAlerting  bool      `json:"fromAlerting"`
+	FromAlerting  bool      `json:"fromalerting"`
 }
 
 type selectOption struct {

--- a/pkg/plugin/types.go
+++ b/pkg/plugin/types.go
@@ -12,6 +12,7 @@ type monitorTelemetryQuery struct {
 	Checks        *[]string `json:"checks"`
 	Instances     *[]string `json:"instances"`
 	IncludeShared bool      `json:"includeshared"`
+	FromAlerting  bool      `json:"fromAlerting"`
 }
 
 type selectOption struct {

--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -2,13 +2,21 @@ import defaults from 'lodash/defaults';
 
 import React, { ChangeEvent, useEffect, useState } from 'react';
 import { InlineField, InlineFieldRow, InlineLabel, InlineSwitch, LoadingPlaceholder, MultiSelect, Select } from '@grafana/ui';
-import { QueryEditorProps, SelectableValue } from '@grafana/data';
+import { QueryEditorProps, SelectableValue, CoreApp } from '@grafana/data';
 import { DataSource } from '../datasource';
 import { defaultQuery, DataSourceOptions, Query } from '../types';
 
 type Props = QueryEditorProps<DataSource, Query, DataSourceOptions>;
 
 export const QueryEditor = (props: Props) => {
+
+  switch (props.app) {
+    case CoreApp.CloudAlerting:
+    case CoreApp.UnifiedAlerting:
+      props.query.fromAlerting = true
+    default:
+      props.query.fromAlerting = false
+  }
 
   const [monitorSelect, setMonitors] = useState<Array<SelectableValue<string>>>();
   const [checkSelect, setChecks] = useState<Array<SelectableValue<string>>>();

--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -13,17 +13,14 @@ export const QueryEditor = (props: Props) => {
   const [checkSelect, setChecks] = useState<Array<SelectableValue<string>>>();
   const [instanceSelect, setInstances] = useState<Array<SelectableValue<string>>>();
   const [buildHash, setBuildHash] = useState<string>();
+  const query = defaults(props.query, defaultQuery);
 
-  // On load set the fromAlerting query var to true if CloudAlerting or UnifiedAlerting
-  useEffect(()=>{
-    const { onChange, query } = props;
-    switch (props.app) {
-      case CoreApp.CloudAlerting:
-      case CoreApp.UnifiedAlerting:
-        onChange({ ...query, fromAlerting: true });
-        break;
-    }   
-  }, [])
+  switch (props.app) {
+    case CoreApp.CloudAlerting:
+    case CoreApp.UnifiedAlerting:
+      query.fromAlerting = true
+      break;
+  }
 
   // Set the initial monitor list and hash
   useEffect(() => {
@@ -152,7 +149,6 @@ export const QueryEditor = (props: Props) => {
     }
   }
 
-  const query = defaults(props.query, defaultQuery);
   const { monitors, queryType } = query;
 
   if (!monitorSelect) {

--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -16,8 +16,8 @@ export const QueryEditor = (props: Props) => {
 
   // On load set the fromAlerting query var to true if CloudAlerting or UnifiedAlerting
   useEffect(()=>{
-    const { onChange, query } = props;
-    switch (props.app) {
+    const { app, onChange, query } = props;
+    switch (app) {
       case CoreApp.CloudAlerting:
       case CoreApp.UnifiedAlerting:
         onChange({ ...query, fromAlerting: true });

--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -9,20 +9,23 @@ import { defaultQuery, DataSourceOptions, Query } from '../types';
 type Props = QueryEditorProps<DataSource, Query, DataSourceOptions>;
 
 export const QueryEditor = (props: Props) => {
-
-  switch (props.app) {
-    case CoreApp.CloudAlerting:
-    case CoreApp.UnifiedAlerting:
-      props.query.fromAlerting = true
-    default:
-      props.query.fromAlerting = false
-  }
-
   const [monitorSelect, setMonitors] = useState<Array<SelectableValue<string>>>();
   const [checkSelect, setChecks] = useState<Array<SelectableValue<string>>>();
   const [instanceSelect, setInstances] = useState<Array<SelectableValue<string>>>();
   const [buildHash, setBuildHash] = useState<string>();
 
+  // On load set the fromAlerting query var to true if CloudAlerting or UnifiedAlerting
+  useEffect(()=>{
+    const { onChange, query } = props;
+    switch (props.app) {
+      case CoreApp.CloudAlerting:
+      case CoreApp.UnifiedAlerting:
+        onChange({ ...query, fromAlerting: true });
+        break;
+    }   
+  }, [])
+
+  // Set the initial monitor list and hash
   useEffect(() => {
     const dataFetch = async () => {
       try {
@@ -194,7 +197,7 @@ export const QueryEditor = (props: Props) => {
         {additionalFormFields(queryType)}
       </InlineFieldRow>
       {additionalFormRows(queryType)}
-      <div><sub>Query Version: {buildHash}</sub></div>
+     <div><sub>Query Version: {buildHash}</sub></div>
     </div>
   );
 }

--- a/src/components/QueryEditor.tsx
+++ b/src/components/QueryEditor.tsx
@@ -16,8 +16,8 @@ export const QueryEditor = (props: Props) => {
 
   // On load set the fromAlerting query var to true if CloudAlerting or UnifiedAlerting
   useEffect(()=>{
-    const { app, onChange, query } = props;
-    switch (app) {
+    const { onChange, query } = props;
+    switch (props.app) {
       case CoreApp.CloudAlerting:
       case CoreApp.UnifiedAlerting:
         onChange({ ...query, fromAlerting: true });

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,7 @@ export interface Query extends DataQuery {
   checks: string[];
   instances: string[];
   includeShared: boolean;
+  fromAlerting: boolean;
 }
 
 export const defaultQuery: Partial<Query> = {


### PR DESCRIPTION
- Updates our local dev to 9.3.6 where I was able to replicate bug
- Updates our data frame format to match TimeSeriesMulti and TimeSeriesWide adhering to contracts here: https://github.com/grafana/grafana-plugin-sdk-go/blob/main/data/contract_docs/timeseries.md. This fixes the js errors and the graphs not reloading. TimeSeriesMulti is used for graphs and alerting and TimeSeriesWide is used for wide table display
- Updates to new openapi spec from backend
- Adds the ability to show a TimeSeriesWide table below graphs in explore mode while still allowing Alerting and Alerting queries to work
- Updates tests

Best way to tests locally is `npm run server:with-plugin-local` against your local running backend or `rpm run server:with-plugin` against dev with a dev key.

Deployment steps:
- [ ] Merge
- [ ] After merge to `main`, generate a new lightweight tag for `v0.0.3` off of main which will automatically generate a draft release through github actions. If the draft release looks good (double check release changelog) then approve the draft release so it becomes the new `latest`

```
git checkout main
git tag v0.0.3
git push origin v0.0.3
```
Internal ref MET-1217
