### PR TITLE
Fix changelog order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,14 @@
 # Changelog
 
-## 0.0.1 (Unreleased)
-
-Initial dev build
-
-## 0.0.2 (Unreleased)
-
-Update release zip name to always be metrist-datasource.zip
-
-## 0.0.3 (Unreleased)
+## 0.0.3
 
 - Fixed error caused by invalid data frames that would sometimes cause the graphs not to refresh and would emit js console errors
 - Added Wide frames for table layout in Explore mode
 
+## 0.0.2
+
+Update release zip name to always be metrist-datasource.zip
+
+## 0.0.1
+
+Initial dev build


### PR DESCRIPTION
Most recent changes need to be at the top for the release action to properly generate release notes
Also marks each version as released now